### PR TITLE
Use Gtk.Application instead of deprecated Granite.Application

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,17 +20,12 @@
 */
 
 namespace Moneta {
-    public class Application : Granite.Application {
+    public class Application : Gtk.Application {
         public MainWindow app_window;
 
         public Application() {
             Object(flags: ApplicationFlags.FLAGS_NONE,
             application_id: "com.github.matfantinel.moneta");
-        }
-
-        construct {
-            exec_name = "com.github.matfantinel.moneta";
-            app_launcher = "com.github.matfantinel.moneta";
         }
 
         protected override void activate() {


### PR DESCRIPTION
[Granite.Application is deprecated](https://github.com/elementary/granite/blob/3c25b6c95e5ddf3fcc3bdf8bf1014f6d2246e677/lib/Application.vala#L25) since 0.5.0 and should not be used anymore.
