### PR TITLE
AppData: Improve first sentence of description

### DIFF
--- a/data/com.github.matfantinel.moneta.appdata.xml.in
+++ b/data/com.github.matfantinel.moneta.appdata.xml.in
@@ -5,12 +5,9 @@
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Moneta</name>
-  <summary>Monitor the exchange rates of real-world currencies on your desktop.</summary>
+  <summary>Monitor the exchange rates of real-world currencies on your desktop</summary>
   <description>
-    <p>
-      Moneta is a handy applet that stays on your desktop and updates the exchange rate of currencies of your choice. 
-      It is a fork from the app Coin by Lains, already on AppCenter, but adapted to handle real-world currencies instead of virtual ones.
-    </p>
+    <p>Keep an eye on the exchange rate of currencies of your choice with this handy applet that stays on your desktop. Moneta is a fork from the app Coin by Lains, already on AppCenter, but adapted to handle real-world currencies instead of virtual ones.</p>
     <p>Features:</p>
     <ul>
       <li>Stays on top of your desktop, giving you a quick glimpse of the exchange rates during the day</li>


### PR DESCRIPTION
The formatting was causing some weird things in AppCenter, plus it's best to not repeat the name of the app in the first sentence.