### PR TITLE
Added Kazakhstani Tenge

### DIFF
--- a/po/com.github.matfantinel.moneta.pot
+++ b/po/com.github.matfantinel.moneta.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.matfantinel.moneta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-02 11:45-0700\n"
+"POT-Creation-Date: 2020-02-20 11:18+0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,60 +17,68 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Objects/Currencies.vala:42
+#: src/Objects/Currencies.vala:44
 msgid "US Dollar"
 msgstr ""
 
-#: src/Objects/Currencies.vala:45
+#: src/Objects/Currencies.vala:47
 msgid "Brazilian Real"
 msgstr ""
 
-#: src/Objects/Currencies.vala:48
+#: src/Objects/Currencies.vala:50
 msgid "Euro"
 msgstr ""
 
-#: src/Objects/Currencies.vala:51
+#: src/Objects/Currencies.vala:53
 msgid "British Pound"
 msgstr ""
 
-#: src/Objects/Currencies.vala:54
+#: src/Objects/Currencies.vala:56
 msgid "Australian Dollar"
 msgstr ""
 
-#: src/Objects/Currencies.vala:57
+#: src/Objects/Currencies.vala:59
 msgid "Canadian Dollar"
 msgstr ""
 
-#: src/Objects/Currencies.vala:60
+#: src/Objects/Currencies.vala:62
 msgid "Chinese Yuan"
 msgstr ""
 
-#: src/Objects/Currencies.vala:63
+#: src/Objects/Currencies.vala:65
 msgid "Indian Rupee"
 msgstr ""
 
-#: src/Objects/Currencies.vala:66
+#: src/Objects/Currencies.vala:68
 msgid "Japanese Yen"
 msgstr ""
 
-#: src/Objects/Currencies.vala:69
+#: src/Objects/Currencies.vala:71
 msgid "Russian Ruble"
 msgstr ""
 
-#: src/Objects/Currencies.vala:72
+#: src/Objects/Currencies.vala:74
 msgid "Swiss Franc"
 msgstr ""
 
-#: src/Objects/Currencies.vala:75
+#: src/Objects/Currencies.vala:77
 msgid "Argentinian Peso"
 msgstr ""
 
-#: src/Objects/Currencies.vala:78
+#: src/Objects/Currencies.vala:80
 msgid "Czech Koruna"
 msgstr ""
 
-#: src/Objects/Currencies.vala:81
+#: src/Objects/Currencies.vala:83
 msgid "Mexican Peso"
+msgstr ""
+
+#: src/Objects/Currencies.vala:86
+msgid "Hungarian Forint"
+msgstr ""
+
+#: src/Objects/Currencies.vala:89
+msgid "Kazakhstani Tenge"
 msgstr ""
 
 #: src/MainWindow.vala:80

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.matfantinel.moneta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-02 11:45-0700\n"
+"POT-Creation-Date: 2020-02-20 11:18+0600\n"
 "PO-Revision-Date: 2020-01-31 12:54-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,61 +18,69 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/Objects/Currencies.vala:42
+#: src/Objects/Currencies.vala:44
 msgid "US Dollar"
 msgstr "Dólar Estadounidense"
 
-#: src/Objects/Currencies.vala:45
+#: src/Objects/Currencies.vala:47
 msgid "Brazilian Real"
 msgstr "Real Brasileño"
 
-#: src/Objects/Currencies.vala:48
+#: src/Objects/Currencies.vala:50
 msgid "Euro"
 msgstr "Euro"
 
-#: src/Objects/Currencies.vala:51
+#: src/Objects/Currencies.vala:53
 msgid "British Pound"
 msgstr "Libra Esterlina"
 
-#: src/Objects/Currencies.vala:54
+#: src/Objects/Currencies.vala:56
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/Objects/Currencies.vala:57
+#: src/Objects/Currencies.vala:59
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
-#: src/Objects/Currencies.vala:60
+#: src/Objects/Currencies.vala:62
 msgid "Chinese Yuan"
 msgstr "Yuan Chino"
 
-#: src/Objects/Currencies.vala:63
+#: src/Objects/Currencies.vala:65
 msgid "Indian Rupee"
 msgstr "Rupia India"
 
-#: src/Objects/Currencies.vala:66
+#: src/Objects/Currencies.vala:68
 msgid "Japanese Yen"
 msgstr "Yen Japonés"
 
-#: src/Objects/Currencies.vala:69
+#: src/Objects/Currencies.vala:71
 msgid "Russian Ruble"
 msgstr "Rublo Ruso"
 
-#: src/Objects/Currencies.vala:72
+#: src/Objects/Currencies.vala:74
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/Objects/Currencies.vala:75
+#: src/Objects/Currencies.vala:77
 msgid "Argentinian Peso"
 msgstr "Peso Argentino"
 
-#: src/Objects/Currencies.vala:78
+#: src/Objects/Currencies.vala:80
 msgid "Czech Koruna"
 msgstr "Corona Checa"
 
-#: src/Objects/Currencies.vala:81
+#: src/Objects/Currencies.vala:83
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
+
+#: src/Objects/Currencies.vala:86
+msgid "Hungarian Forint"
+msgstr ""
+
+#: src/Objects/Currencies.vala:89
+msgid "Kazakhstani Tenge"
+msgstr ""
 
 #: src/MainWindow.vala:80
 msgid "Updated every 10 minutes"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.matfantinel.moneta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-02 11:45-0700\n"
+"POT-Creation-Date: 2020-02-20 11:18+0600\n"
 "PO-Revision-Date: 2020-01-31 13:44+0100\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
@@ -17,62 +17,70 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/Objects/Currencies.vala:42
+#: src/Objects/Currencies.vala:44
 msgid "US Dollar"
 msgstr "Dollar américain"
 
-#: src/Objects/Currencies.vala:45
+#: src/Objects/Currencies.vala:47
 msgid "Brazilian Real"
 msgstr "Réal brésilien"
 
-#: src/Objects/Currencies.vala:48
+#: src/Objects/Currencies.vala:50
 msgid "Euro"
 msgstr "Euro"
 
-#: src/Objects/Currencies.vala:51
+#: src/Objects/Currencies.vala:53
 msgid "British Pound"
 msgstr "Livre sterling"
 
-#: src/Objects/Currencies.vala:54
+#: src/Objects/Currencies.vala:56
 msgid "Australian Dollar"
 msgstr "Dollar australien"
 
-#: src/Objects/Currencies.vala:57
+#: src/Objects/Currencies.vala:59
 msgid "Canadian Dollar"
 msgstr "Dollar canadien"
 
-#: src/Objects/Currencies.vala:60
+#: src/Objects/Currencies.vala:62
 msgid "Chinese Yuan"
 msgstr "Yuan chinois"
 
-#: src/Objects/Currencies.vala:63
+#: src/Objects/Currencies.vala:65
 msgid "Indian Rupee"
 msgstr "Roupie indienne"
 
-#: src/Objects/Currencies.vala:66
+#: src/Objects/Currencies.vala:68
 msgid "Japanese Yen"
 msgstr "Yen japonais"
 
-#: src/Objects/Currencies.vala:69
+#: src/Objects/Currencies.vala:71
 msgid "Russian Ruble"
 msgstr "Rouble russe"
 
-#: src/Objects/Currencies.vala:72
+#: src/Objects/Currencies.vala:74
 msgid "Swiss Franc"
 msgstr "Franc suisse"
 
-#: src/Objects/Currencies.vala:75
+#: src/Objects/Currencies.vala:77
 msgid "Argentinian Peso"
 msgstr "Peso argentin"
 
-#: src/Objects/Currencies.vala:78
+#: src/Objects/Currencies.vala:80
 msgid "Czech Koruna"
 msgstr "Couronne tchèque"
 
-#: src/Objects/Currencies.vala:81
+#: src/Objects/Currencies.vala:83
 #, fuzzy
 msgid "Mexican Peso"
 msgstr "Peso mexicain"
+
+#: src/Objects/Currencies.vala:86
+msgid "Hungarian Forint"
+msgstr ""
+
+#: src/Objects/Currencies.vala:89
+msgid "Kazakhstani Tenge"
+msgstr ""
 
 #: src/MainWindow.vala:80
 msgid "Updated every 10 minutes"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.matfantinel.moneta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-31 12:54-0300\n"
+"POT-Creation-Date: 2020-02-20 11:18+0600\n"
 "PO-Revision-Date: 2020-01-31 13:44+0100\n"
 "Last-Translator: Óvári (@ovari)\n"
 "Language-Team: none\n"
@@ -17,57 +17,70 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/Objects/Currencies.vala:41
+#: src/Objects/Currencies.vala:44
 msgid "US Dollar"
 msgstr "amerikai dollár"
 
-#: src/Objects/Currencies.vala:44
+#: src/Objects/Currencies.vala:47
 msgid "Brazilian Real"
 msgstr "brazíliai real"
 
-#: src/Objects/Currencies.vala:47
+#: src/Objects/Currencies.vala:50
 msgid "Euro"
 msgstr "euró"
 
-#: src/Objects/Currencies.vala:50
+#: src/Objects/Currencies.vala:53
 msgid "British Pound"
 msgstr "brit font"
 
-#: src/Objects/Currencies.vala:53
+#: src/Objects/Currencies.vala:56
 msgid "Australian Dollar"
 msgstr "ausztrál dollár"
 
-#: src/Objects/Currencies.vala:56
+#: src/Objects/Currencies.vala:59
 msgid "Canadian Dollar"
 msgstr "kanadai dollár"
 
-#: src/Objects/Currencies.vala:59
+#: src/Objects/Currencies.vala:62
 msgid "Chinese Yuan"
 msgstr "kínai jüan"
 
-#: src/Objects/Currencies.vala:62
+#: src/Objects/Currencies.vala:65
 msgid "Indian Rupee"
 msgstr "indiai rúpia"
 
-#: src/Objects/Currencies.vala:65
+#: src/Objects/Currencies.vala:68
 msgid "Japanese Yen"
 msgstr "japán jen"
 
-#: src/Objects/Currencies.vala:68
+#: src/Objects/Currencies.vala:71
 msgid "Russian Ruble"
 msgstr "orosz rubel"
 
-#: src/Objects/Currencies.vala:71
+#: src/Objects/Currencies.vala:74
 msgid "Swiss Franc"
 msgstr "svájci frank"
 
-#: src/Objects/Currencies.vala:74
+#: src/Objects/Currencies.vala:77
 msgid "Argentinian Peso"
 msgstr "argentin peso"
 
-#: src/Objects/Currencies.vala:77
+#: src/Objects/Currencies.vala:80
 msgid "Czech Koruna"
 msgstr "cseh korona"
+
+#: src/Objects/Currencies.vala:83
+#, fuzzy
+msgid "Mexican Peso"
+msgstr "argentin peso"
+
+#: src/Objects/Currencies.vala:86
+msgid "Hungarian Forint"
+msgstr ""
+
+#: src/Objects/Currencies.vala:89
+msgid "Kazakhstani Tenge"
+msgstr ""
 
 #: src/MainWindow.vala:80
 msgid "Updated every 10 minutes"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.matfantinel.moneta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-02 11:45-0700\n"
+"POT-Creation-Date: 2020-02-20 11:18+0600\n"
 "PO-Revision-Date: 2020-01-31 12:54-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,62 +18,70 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/Objects/Currencies.vala:42
+#: src/Objects/Currencies.vala:44
 msgid "US Dollar"
 msgstr "Доллар США"
 
-#: src/Objects/Currencies.vala:45
+#: src/Objects/Currencies.vala:47
 msgid "Brazilian Real"
 msgstr "Бразильский Реал"
 
-#: src/Objects/Currencies.vala:48
+#: src/Objects/Currencies.vala:50
 msgid "Euro"
 msgstr "Евро"
 
-#: src/Objects/Currencies.vala:51
+#: src/Objects/Currencies.vala:53
 msgid "British Pound"
 msgstr "Фунт стерлингов"
 
-#: src/Objects/Currencies.vala:54
+#: src/Objects/Currencies.vala:56
 msgid "Australian Dollar"
 msgstr "Австралийский доллар"
 
-#: src/Objects/Currencies.vala:57
+#: src/Objects/Currencies.vala:59
 msgid "Canadian Dollar"
 msgstr "Канадский доллар"
 
-#: src/Objects/Currencies.vala:60
+#: src/Objects/Currencies.vala:62
 msgid "Chinese Yuan"
 msgstr "Китайский юань"
 
-#: src/Objects/Currencies.vala:63
+#: src/Objects/Currencies.vala:65
 msgid "Indian Rupee"
 msgstr "Индийская рупия"
 
-#: src/Objects/Currencies.vala:66
+#: src/Objects/Currencies.vala:68
 msgid "Japanese Yen"
 msgstr "Японская иена"
 
-#: src/Objects/Currencies.vala:69
+#: src/Objects/Currencies.vala:71
 msgid "Russian Ruble"
 msgstr "Российский рубль"
 
-#: src/Objects/Currencies.vala:72
+#: src/Objects/Currencies.vala:74
 msgid "Swiss Franc"
 msgstr "Швейцарский фанк"
 
-#: src/Objects/Currencies.vala:75
+#: src/Objects/Currencies.vala:77
 msgid "Argentinian Peso"
 msgstr "Аргентинский песо"
 
-#: src/Objects/Currencies.vala:78
+#: src/Objects/Currencies.vala:80
 msgid "Czech Koruna"
 msgstr "Чешская крона"
 
-#: src/Objects/Currencies.vala:81
+#: src/Objects/Currencies.vala:83
 #, fuzzy
 msgid "Mexican Peso"
 msgstr "Мексиканское песо"
+
+#: src/Objects/Currencies.vala:86
+msgid "Hungarian Forint"
+msgstr "Венгерский форинт"
+
+#: src/Objects/Currencies.vala:89
+msgid "Kazakhstani Tenge"
+msgstr "Казахстанский тенге"
 
 #: src/MainWindow.vala:80
 msgid "Updated every 10 minutes"

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -202,7 +202,8 @@ namespace Moneta {
                 Currency.ARGENTINIAN_PESO.get_friendly_name(),
                 Currency.CZECH_KORUNA.get_friendly_name(),
                 Currency.MEXICAN_PESO.get_friendly_name(),
-                Currency.HUNGARIAN_FORINT.get_friendly_name()
+                Currency.HUNGARIAN_FORINT.get_friendly_name(),
+                Currency.KAZAKHSTANI_TENGE.get_friendly_name()
             };
             Gtk.ListStore source_list_store = new Gtk.ListStore(1, typeof(string));
 

--- a/src/Objects/Currencies.vala
+++ b/src/Objects/Currencies.vala
@@ -35,7 +35,8 @@ namespace Moneta {
         ARGENTINIAN_PESO,
         CZECH_KORUNA,
         MEXICAN_PESO,
-        HUNGARIAN_FORINT;
+        HUNGARIAN_FORINT,
+        KAZAKHSTANI_TENGE;
 
         public string get_friendly_name() {
             switch (this) {   
@@ -83,6 +84,9 @@ namespace Moneta {
 
                 case HUNGARIAN_FORINT:
                     return _("Hungarian Forint");
+
+                case KAZAKHSTANI_TENGE:
+                    return _("Kazakhstani Tenge");
 
                 default:
                     assert_not_reached();
@@ -135,6 +139,9 @@ namespace Moneta {
 
                 case HUNGARIAN_FORINT:
                     return "HUF";
+
+                case KAZAKHSTANI_TENGE:
+                    return "KZT";
     
                 default:
                     assert_not_reached();
@@ -187,6 +194,9 @@ namespace Moneta {
 
                 case HUNGARIAN_FORINT:
                     return "Ft";
+
+                case KAZAKHSTANI_TENGE:
+                    return "₸";
     
                 default:
                     assert_not_reached();


### PR DESCRIPTION
I added Kazakhstani Tenge (KZT) to the list of currencies, as well as updated the translations. Thank you for Moneta!